### PR TITLE
Call bie using HTTPS

### DIFF
--- a/commonui-bs2/js/application.js
+++ b/commonui-bs2/js/application.js
@@ -2,7 +2,7 @@
 $(function(){
     // autocomplete on navbar search input
     // autocomplete on navbar search input
-    $("#biesearch").autocomplete('http://bie.ala.org.au/ws/search/auto.jsonp', {
+    $("#biesearch").autocomplete('https://bie.ala.org.au/ws/search/auto.jsonp', {
         extraParams: {limit: 100},
         dataType: 'jsonp',
         parse: function(data) {


### PR DESCRIPTION
Calls the bie autocomplete service using HTTPS so that this script can be used on HTTPS sites. This does not affect its use on HTTP sites, as all browsers are capable of calling HTTPS websites from HTTP pages.